### PR TITLE
build: Apply new logo to the site

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,6 +12,7 @@ DefaultContentLanguage = "sv"
   author = "authors"
 
 [params]
+  logoPath = "/img/logo/ix-drone-logo-white.svg"
   github = "https://github.com/ix-sthlm/"
   meetup = "https://meetup.com/IX-Stockholm"
   rss = true

--- a/default.nix
+++ b/default.nix
@@ -35,6 +35,7 @@ in stdenv.mkDerivation rec {
     make latex
     make dirlists
     make hugo
+    make replace-favicon
     make cname
   '';
 


### PR DESCRIPTION
To test builds I usually make sure to have python3 available (to have a webserver), by for example entering a shell with python `nix-shell --run fish -p python3`.

Then I build it and serve the directory with my webserver like this:
`nix-build; pushd result/; python -m http.server; popd`

And then I visit my localhost to see the result: http://localhost:8000/

It can be done without nix... but nix is so much easier...