### PR TITLE
Remove dead Meetup link in sidebar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,6 @@ DefaultContentLanguage = "sv"
 [params]
   embedLogoPath = "static/img/logo/ix-drone-logo-spin-magenta.svg"
   github = "https://github.com/ix-sthlm/"
-  meetup = "https://meetup.com/IX-Stockholm"
   rss = true
   sidebar_license_page = false
 


### PR DESCRIPTION
Not sure if this is the only change needed to remove Meetup from the sidebar, but this was the only thing I could find.