### PR TITLE
Ta bort inaktuell information om UFS lokal

### DIFF
--- a/content/about.en.md
+++ b/content/about.en.md
@@ -24,20 +24,6 @@ Box 8006
 Sweden
 ```
 
-### Visit us
-IX houses at [UFS](http://ufs.se/) place on Mondays from around 18:00. UFS
-place has the address:
-```
-Unga Forskare Stockholm
-Polhemsgatan 38
-112 30 Stockholm
-Sweden
-```
-
-<iframe src="https://www.openstreetmap.org/export/embed.html?bbox=18.025871515274048%2C59.32980197428491%2C18.05054783821106%2C59.33683370733963&amp;layer=mapnik&amp;marker=59.333318022731746%2C18.038209676742554" style="border: 1px solid black; width: 100%; height: 350px;"></iframe>
-
-[See bigger map](https://www.openstreetmap.org/?mlat=59.33332&amp;mlon=18.03821#map=17/59.33332/18.03821)
-
 ### Internet Relay Chat
 IX has a channel by the name [#ix on irc.oftc.net](irc://irc.oftc.net/ix). You're
 free to join with any IRC-client or use the <a href="https://webchat.oftc.net/?channels=ix" target="_blank">webclient</a> below.

--- a/content/about.en.md
+++ b/content/about.en.md
@@ -8,12 +8,6 @@ Stockholm.
 ### Email
 You can send emails to the board at [ix@ufs.se](mailto:ix@ufs.se).
 
-### Phone
-There's a phone in UFS that you can call to. If you want to reach IX it's best
-to call during Monday evenings.
-
-The number there is [+46 8-10 77 00](tel:+468-10-77-00).
-
 ### Postal address
 To send letters to IX, you can do it to:
 ```

--- a/content/about.md
+++ b/content/about.md
@@ -27,19 +27,6 @@ Box 8006
 104 20 Stockholm
 ```
 
-### Besök oss
-IX håller till i [UFS](http://ufs.se/) lokal på måndagar från klockan 18. UFS
-lokal har följande adress:
-```
-Unga Forskare Stockholm
-Polhemsgatan 38
-112 30 Stockholm
-```
-
-<iframe src="https://www.openstreetmap.org/export/embed.html?bbox=18.025871515274048%2C59.32980197428491%2C18.05054783821106%2C59.33683370733963&amp;layer=mapnik&amp;marker=59.333318022731746%2C18.038209676742554" style="border: 1px solid black; width: 100%; height: 350px;"></iframe>
-
-[Se större karta](https://www.openstreetmap.org/?mlat=59.33332&amp;mlon=18.03821#map=17/59.33332/18.03821)
-
 ### Internet Relay Chat
 IX har en kanal vid namn [#ix på irc.oftc.net](irc://irc.oftc.net/ix). Det går
 utmärkt att ansluta sig dit med valfri IRC-Klient eller använda <a href="https://webchat.oftc.net/?channels=ix" target="_blank">webbklienten</a>

--- a/content/about.md
+++ b/content/about.md
@@ -12,12 +12,6 @@ Bankkonto: PlusGiro, Nordea, 189 97-7
 ### Epost
 Det går att eposta till styrelsen samt revisor på [ix@ufs.se](mailto:ix@ufs.se).
 
-### Telefon
-Det finns en telefon i UFS lokal som det går att ringa till, om man vill nå IX
-så är det bäst att ringa på måndags kvällar.
-
-Nummret dit är [08-10 77 00](tel:+468-10-77-00).
-
 ### Postadress
 Det går att skicka post till IX på följande adress:
 ```


### PR DESCRIPTION
Ta bort "besök oss" och "telefon" sektionerna på "om oss" sidorna eftersom 1) UFS lokal lägger ner och 2) SUGA tar över UFS telefonnummer. Postadress borde också ändras egentligen, men jag vet inte vad det ska ändras till.