### PR TITLE
[annual-meeting-2024] Publish annual meeting post

### DIFF
--- a/content/post/2024/2024-03-02-annual-general-meeting.md
+++ b/content/post/2024/2024-03-02-annual-general-meeting.md
@@ -1,0 +1,58 @@
+---
+authors: [ "etu" ]
+categories: [ "Årsmöte", "Möte" ]
+date: "2024-03-01T18:00:00+01:00"
+title: "Inbjudan till Årsmöte 2024"
+---
+
+Nu har tiden kommit för IX Årsmöte! I år är det den 7:e april och
+börjar klockan XX:XX och planerat avslut senast YY. Platsen är online.
+Alla intresserade är naturligtvis välkomna.
+
+Vi kommer att avhandla en proposition om föreningens upplösning.
+
+## Mötesupplägg
+
+Vi kommer att köra mötet på Google Meet. Länken kommer att delas på
+IRC strax innan mötet börjar samt att denna bloggpost kommer
+uppdateras med en länk till mötet innan mötet
+öppnas. Mötessekreteraren kommer dela skärm för realtidsuppdatering av
+protokollet.
+
+## Dagordning
+
+ 1. Öppnande av mötet
+ 2. Mötesfunktionärer
+    1. Val av mötesordförande
+    2. Val av mötessekreterare
+    3. Val av justeringspersoner tillika rösträknare
+ 3. Mötets behörighet
+ 4. Fastställande av röstlängd
+ 5. Fastställande av dagordningen
+ 6. Föredrag av Verksamhetsberättelse
+ 7. Föredrag av Ekonomisk berättelse
+ 8. Föredrag av Revisionsberättelse
+ 9. Fråga om styrelsens ansvarsfrihet
+ 10. Propositioner
+     1. Proposition 1: Upplösning av föreningen
+ 11. Fastställande av medlemsavgift
+ 12. Verksamhetsplan
+ 13. Budget
+ 14. Motioner
+ 15. Förtroendeval
+     1. Val av ordförande
+     2. Val av styrelseledamöter
+     3. Val av revisorer
+     4. Val av valberedning
+ 16. Övriga frågor
+ 17. Mötets avslutande
+
+## Dokument
+
+- [Verksamhetsberättelse för 2021-2023](/documents/2024/annual-meeting/annual-report-2021-2023.pdf)
+- [Ekonomisk berättelse för 2021-2023](/documents/2024/annual-meeting/financial-report-2021-2023.pdf)
+- [Budgetförslag för 2024](/documents/2024/annual-meeting/proposed-budget-2024.pdf)
+- [Verksamhetsplan för 2024](/documents/2024/annual-meeting/proposed-operation-plan-2024.pdf)
+- [IX Årsmöteshandlingar 2024](/documents/2024/annual-meeting/combined-document.pdf)
+- [Proposition 1: Upplösning av föreningen](/documents/2024/annual-meeting/proposition-1-disband-the-organization.pdf)
+- [Stadgar](/documents/stadgar.pdf)

--- a/documents/2024/annual-meeting/annual-report-2021-2023.org
+++ b/documents/2024/annual-meeting/annual-report-2021-2023.org
@@ -1,0 +1,14 @@
+#+TITLE: Verksamhetsberättelse 2021-2023
+#+DATE: 2024-03-02
+#+OPTIONS: toc:nil author:nil
+#+LANGUAGE: sv
+#+LATEX_CLASS: article
+#+LATEX_CLASS_OPTIONS: [a4paper]
+#+LATEX_HEADER: \usepackage[swedish]{babel}
+#+LATEX_HEADER: \setlength{\parindent}{0pt}
+#+LATEX_HEADER: \setlength{\parskip}{6pt}
+
+Vi har:
+- Vi tömde våra saker ur lokalen
+- Vi hade måndagsträffar så länge lokalen fanns kvar
+- Vi migrerade vår hemsida till proxxi.org

--- a/documents/2024/annual-meeting/combined-document.org
+++ b/documents/2024/annual-meeting/combined-document.org
@@ -1,0 +1,61 @@
+#+TITLE: IX Årsmöteshandlingar 2024
+#+DATE: 2024-03-02
+#+OPTIONS: toc:t author:nil
+#+LANGUAGE: sv
+#+LATEX_CLASS: article
+#+LATEX_CLASS_OPTIONS: [a4paper]
+#+LATEX_HEADER: \usepackage[swedish]{babel}
+
+\clearpage
+
+* Dagordning
+1. Öppnande av mötet
+2. Mötesfunktionärer
+  1. Val av mötesordförande
+  2. Val av mötessekreterare
+  3. Val av justeringspersoner tillika rösträknare
+3. Mötets behörighet
+4. Fastställande av röstlängd
+5. Fastställande av dagordningen
+6. Föredrag av Verksamhetsberättelse
+7. Föredrag av Ekonomisk berättelse
+8. Föredrag av Revisionsberättelse
+9. Fråga om styrelsens ansvarsfrihet
+10. Propositioner
+  1. Proposition 1: Upplösning av föreningen
+11. Fastställande av medlemsavgift
+12. Verksamhetsplan
+13. Budget
+14. Motioner
+15. Förtroendeval
+  1. Val av ordförande
+  2. Val av styrelseledamöter
+  3. Val av revisorer
+  4. Val av valberedning
+16. Övriga frågor
+17. Mötets avslutande
+
+\clearpage
+
+* Verksamhetsberättelse 2021-2023
+#+INCLUDE: "./annual-report-2021-2023.org" :lines "10-"
+
+\clearpage
+
+* Ekonomisk Berättelse för IX 2021-2023
+#+INCLUDE: "./financial-report-2021-2023.org" :lines "10-"
+
+\clearpage
+
+* Budgetförslag för IX 2024
+#+INCLUDE: "./proposed-budget-2024.org" :lines "10-"
+
+\clearpage
+
+* Föreslagen Verksamhetsplan 2024
+#+INCLUDE: "./proposed-operation-plan-2024.org" :lines "10-"
+
+\clearpage
+
+* Proposition 1: Upplösning av föreningen
+#+INCLUDE: "./proposition-1-disband-the-organization.org" :lines "10-"

--- a/documents/2024/annual-meeting/financial-report-2021-2023.org
+++ b/documents/2024/annual-meeting/financial-report-2021-2023.org
@@ -1,0 +1,27 @@
+#+TITLE: Ekonomisk Berättelse för IX 2021-2023
+#+DATE: 2024-03-02
+#+OPTIONS: toc:nil author:nil
+#+LANGUAGE: sv
+#+LATEX_CLASS: article
+#+LATEX_CLASS_OPTIONS: [a4paper]
+#+LATEX_HEADER: \usepackage[swedish]{babel}
+#+LATEX_HEADER: \setlength{\parindent}{0pt}
+#+LATEX_HEADER: \setlength{\parskip}{6pt}
+
+* Kontoutdrag
+|      Datum | Till/Från | Belopp | Utgående Saldo | Beskrivning              |
+|------------+-----------+--------+----------------+--------------------------|
+| 2021-01-01 |           |      0 |       45389.01 | Ingående saldo från 2020 |
+| 2021-01-07 | Nordea    |   -950 |       44439.01 | PRIS ENL SPEC            |
+| 2021-03-29 | IX        |   1300 |       45739.01 | Försäljning av saker     |
+| 2021-12-06 | IX        |   2838 |       48577.01 | UFS bidrag               |
+| 2022-01-01 |           |      0 |       48577.01 | Ingående saldo från 2021 |
+| 2022-01-05 | Nordea    |   -950 |       47627.01 | PRIS ENL SPEC            |
+| 2023-01-01 |           |      0 |       47627.01 | Ingående saldo från 2022 |
+| 2023-01-04 | Nordea    |   -950 |       46677.01 | PRIS ENL SPEC            |
+#+TBLFM: @3$4..@>$4=@-1 + $3
+
+* Sammanfattning
+Under 2021-2023 så fick vi in en betalning i form av försäljning av saker
+samt UFS bidrag en gång. Utöver det har samtlig kontoaktivitet bestått av
+Nordeas kostnader.

--- a/documents/2024/annual-meeting/proposed-budget-2024.org
+++ b/documents/2024/annual-meeting/proposed-budget-2024.org
@@ -1,0 +1,21 @@
+#+TITLE: Budgetförslag för IX 2024
+#+DATE: 2021-03-01
+#+OPTIONS: toc:nil author:nil
+#+LANGUAGE: sv
+#+LATEX_CLASS: article
+#+LATEX_CLASS_OPTIONS: [a4paper]
+#+LATEX_HEADER: \usepackage[swedish]{babel}
+#+LATEX_HEADER: \setlength{\parindent}{0pt}
+#+LATEX_HEADER: \setlength{\parskip}{6pt}
+
+| Inkomster        |          |
+|------------------+----------|
+| Ingående balans  | 46677.01 |
+|------------------+----------|
+|                  |          |
+| Utgifter         |          |
+|------------------+----------|
+| Nordea bankkonto |   950.00 |
+|------------------+----------|
+| Utgånde balans   | 45727.01 |
+#+TBLFM: @>$2=vsum(@I..@II) - vsum(@III..@IIII)

--- a/documents/2024/annual-meeting/proposed-operation-plan-2024.org
+++ b/documents/2024/annual-meeting/proposed-operation-plan-2024.org
@@ -1,0 +1,12 @@
+#+TITLE: Föreslagen Verksamhetsplan 2024
+#+DATE: 2021-03-01
+#+OPTIONS: toc:nil author:nil
+#+LANGUAGE: sv
+#+LATEX_CLASS: article
+#+LATEX_CLASS_OPTIONS: [a4paper]
+#+LATEX_HEADER: \usepackage[swedish]{babel}
+#+LATEX_HEADER: \setlength{\parindent}{0pt}
+#+LATEX_HEADER: \setlength{\parskip}{6pt}
+
+Vi vill:
+- Avveckla föreningen?

--- a/documents/2024/annual-meeting/proposition-1-disband-the-organization.org
+++ b/documents/2024/annual-meeting/proposition-1-disband-the-organization.org
@@ -1,0 +1,17 @@
+#+TITLE: Proposition 1: Upplösning av föreningen
+#+DATE: 2024-03-02
+#+OPTIONS: toc:nil author:nil num:nil
+#+LANGUAGE: sv
+#+LATEX_CLASS: article
+#+LATEX_CLASS_OPTIONS: [a4paper]
+#+LATEX_HEADER: \usepackage[swedish]{babel}
+#+LATEX_HEADER: \setlength{\parindent}{0pt}
+#+LATEX_HEADER: \setlength{\parskip}{6pt}
+
+Motionärer: Elis Hirwing
+
+Då föreningen inte har haft någon verksamhet på länge så skulle jag vilja
+lägga ner föreningen.
+
+Föreningen sitter på en summa pengar som behöver disponeras men har i övrigt
+inga tillgångar.


### PR DESCRIPTION
Tid och datum är än så länge inte helt spikat. Men jag tycker att verksamhetsberättelse, ekonomi osv borde vara i sin ordning.

Jag har markerat alla i styrelsen från förra årsmötet som reviewers: https://proxxi.org/documents/2021/annual-meeting/annual-meeting-protocol-2021.pdf

Jag har även letat upp senaste medlemslistan från att vi faktiskt hade verksamhet, jag tänker att vi borde ha den som utgångspunkt för rösträtt för att undvika kuppning om hur resurser fördelas.